### PR TITLE
Cisco sso zookeeper

### DIFF
--- a/src/zookeeper/Chart.yaml
+++ b/src/zookeeper/Chart.yaml
@@ -1,7 +1,8 @@
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 1.0.3
-appVersion: 3.4.10
+version: 2.1.1
+appVersion: 3.5.5
+kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,
   providing distributed synchronization, and providing group services.
 icon: https://zookeeper.apache.org/images/zookeeper_small.gif

--- a/src/zookeeper/templates/_helpers.tpl
+++ b/src/zookeeper/templates/_helpers.tpl
@@ -30,3 +30,17 @@ Create chart name and version as used by the chart label.
 {{- define "zookeeper.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+The name of the zookeeper headless service.
+*/}}
+{{- define "zookeeper.headless" -}}
+{{- printf "%s-headless" (include "zookeeper.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the zookeeper chroots job.
+*/}}
+{{- define "zookeeper.chroots" -}}
+{{- printf "%s-chroots" (include "zookeeper.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/src/zookeeper/templates/config-script.yaml
+++ b/src/zookeeper/templates/config-script.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "zookeeper.fullname" . }}
+  labels:
+    app: {{ template "zookeeper.name" . }}
+    chart: {{ template "zookeeper.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: server
+data:
+    ok: |
+      #!/bin/sh
+      zkServer.sh status
+
+    ready: |
+      #!/bin/sh
+      echo ruok | nc 127.0.0.1 ${1:-2181}
+
+    run: |
+      #!/bin/bash
+
+      set -a
+      ROOT=$(echo /apache-zookeeper-*)
+
+      ZK_USER=${ZK_USER:-"zookeeper"}
+      ZK_LOG_LEVEL=${ZK_LOG_LEVEL:-"INFO"}
+      ZK_DATA_DIR=${ZK_DATA_DIR:-"/data"}
+      ZK_DATA_LOG_DIR=${ZK_DATA_LOG_DIR:-"/data/log"}
+      ZK_CONF_DIR=${ZK_CONF_DIR:-"/conf"}
+      ZK_CLIENT_PORT=${ZK_CLIENT_PORT:-2181}
+      ZK_SERVER_PORT=${ZK_SERVER_PORT:-2888}
+      ZK_ELECTION_PORT=${ZK_ELECTION_PORT:-3888}
+      ZK_TICK_TIME=${ZK_TICK_TIME:-2000}
+      ZK_INIT_LIMIT=${ZK_INIT_LIMIT:-10}
+      ZK_SYNC_LIMIT=${ZK_SYNC_LIMIT:-5}
+      ZK_HEAP_SIZE=${ZK_HEAP_SIZE:-2G}
+      ZK_MAX_CLIENT_CNXNS=${ZK_MAX_CLIENT_CNXNS:-60}
+      ZK_MIN_SESSION_TIMEOUT=${ZK_MIN_SESSION_TIMEOUT:- $((ZK_TICK_TIME*2))}
+      ZK_MAX_SESSION_TIMEOUT=${ZK_MAX_SESSION_TIMEOUT:- $((ZK_TICK_TIME*20))}
+      ZK_SNAP_RETAIN_COUNT=${ZK_SNAP_RETAIN_COUNT:-3}
+      ZK_PURGE_INTERVAL=${ZK_PURGE_INTERVAL:-0}
+      ID_FILE="$ZK_DATA_DIR/myid"
+      ZK_CONFIG_FILE="$ZK_CONF_DIR/zoo.cfg"
+      LOG4J_PROPERTIES="$ZK_CONF_DIR/log4j.properties"
+      HOST=$(hostname)
+      DOMAIN=`hostname -d`
+      ZOOCFG=zoo.cfg
+      ZOOCFGDIR=$ZK_CONF_DIR
+      JVMFLAGS="-Xmx$ZK_HEAP_SIZE -Xms$ZK_HEAP_SIZE"
+
+      APPJAR=$(echo $ROOT/*jar)
+      CLASSPATH="${ROOT}/lib/*:${APPJAR}:${ZK_CONF_DIR}:"
+
+      if [[ $HOST =~ (.*)-([0-9]+)$ ]]; then
+          NAME=${BASH_REMATCH[1]}
+          ORD=${BASH_REMATCH[2]}
+          MY_ID=$((ORD+1))
+      else
+          echo "Failed to extract ordinal from hostname $HOST"
+          exit 1
+      fi
+
+      mkdir -p $ZK_DATA_DIR
+      mkdir -p $ZK_DATA_LOG_DIR
+      echo $MY_ID >> $ID_FILE
+
+      echo "clientPort=$ZK_CLIENT_PORT" >> $ZK_CONFIG_FILE
+      echo "dataDir=$ZK_DATA_DIR" >> $ZK_CONFIG_FILE
+      echo "dataLogDir=$ZK_DATA_LOG_DIR" >> $ZK_CONFIG_FILE
+      echo "tickTime=$ZK_TICK_TIME" >> $ZK_CONFIG_FILE
+      echo "initLimit=$ZK_INIT_LIMIT" >> $ZK_CONFIG_FILE
+      echo "syncLimit=$ZK_SYNC_LIMIT" >> $ZK_CONFIG_FILE
+      echo "maxClientCnxns=$ZK_MAX_CLIENT_CNXNS" >> $ZK_CONFIG_FILE
+      echo "minSessionTimeout=$ZK_MIN_SESSION_TIMEOUT" >> $ZK_CONFIG_FILE
+      echo "maxSessionTimeout=$ZK_MAX_SESSION_TIMEOUT" >> $ZK_CONFIG_FILE
+      echo "autopurge.snapRetainCount=$ZK_SNAP_RETAIN_COUNT" >> $ZK_CONFIG_FILE
+      echo "autopurge.purgeInterval=$ZK_PURGE_INTERVAL" >> $ZK_CONFIG_FILE
+      echo "4lw.commands.whitelist=*" >> $ZK_CONFIG_FILE
+
+      for (( i=1; i<=$ZK_REPLICAS; i++ ))
+      do
+          echo "server.$i=$NAME-$((i-1)).$DOMAIN:$ZK_SERVER_PORT:$ZK_ELECTION_PORT" >> $ZK_CONFIG_FILE
+      done
+
+      rm -f $LOG4J_PROPERTIES
+
+      echo "zookeeper.root.logger=$ZK_LOG_LEVEL, CONSOLE" >> $LOG4J_PROPERTIES
+      echo "zookeeper.console.threshold=$ZK_LOG_LEVEL" >> $LOG4J_PROPERTIES
+      echo "zookeeper.log.threshold=$ZK_LOG_LEVEL" >> $LOG4J_PROPERTIES
+      echo "zookeeper.log.dir=$ZK_DATA_LOG_DIR" >> $LOG4J_PROPERTIES
+      echo "zookeeper.log.file=zookeeper.log" >> $LOG4J_PROPERTIES
+      echo "zookeeper.log.maxfilesize=256MB" >> $LOG4J_PROPERTIES
+      echo "zookeeper.log.maxbackupindex=10" >> $LOG4J_PROPERTIES
+      echo "zookeeper.tracelog.dir=$ZK_DATA_LOG_DIR" >> $LOG4J_PROPERTIES
+      echo "zookeeper.tracelog.file=zookeeper_trace.log" >> $LOG4J_PROPERTIES
+      echo "log4j.rootLogger=\${zookeeper.root.logger}" >> $LOG4J_PROPERTIES
+      echo "log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender" >> $LOG4J_PROPERTIES
+      echo "log4j.appender.CONSOLE.Threshold=\${zookeeper.console.threshold}" >> $LOG4J_PROPERTIES
+      echo "log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout" >> $LOG4J_PROPERTIES
+      echo "log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n" >> $LOG4J_PROPERTIES
+
+      if [ -n "$JMXDISABLE" ]
+      then
+          MAIN=org.apache.zookeeper.server.quorum.QuorumPeerMain
+      else
+          MAIN="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=$JMXPORT -Dcom.sun.management.jmxremote.authenticate=$JMXAUTH -Dcom.sun.management.jmxremote.ssl=$JMXSSL -Dzookeeper.jmx.log4j.disable=$JMXLOG4J org.apache.zookeeper.server.quorum.QuorumPeerMain"
+      fi
+
+      set -x
+      exec java -cp "$CLASSPATH" $JVMFLAGS $MAIN $ZK_CONFIG_FILE

--- a/src/zookeeper/templates/job-chroots.yaml
+++ b/src/zookeeper/templates/job-chroots.yaml
@@ -4,7 +4,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "zookeeper.fullname" . }}-chroots
+  name: {{ template "zookeeper.chroots" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
@@ -30,6 +30,9 @@ spec:
         job: chroots
     spec:
       restartPolicy: {{ $job.restartPolicy }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
       containers:
         - name: main
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/src/zookeeper/templates/service-headless.yaml
+++ b/src/zookeeper/templates/service-headless.yaml
@@ -1,19 +1,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "zookeeper.fullname" . }}-headless
+  name: {{ template "zookeeper.headless" . }}
   labels:
     app: {{ template "zookeeper.name" . }}
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.headless.annotations }}
+  annotations:
+{{ .Values.headless.annotations | toYaml | trimSuffix "\n" | indent 4 }}
+{{- end }}
 spec:
   clusterIP: None
   ports:
 {{- range $key, $port := .Values.ports }}
     - name: {{ $key }}
       port: {{ $port.containerPort }}
-      targetPort: {{ $port.name }}
+      targetPort: {{ $key }}
       protocol: {{ $port.protocol }}
 {{- end }}
   selector:

--- a/src/zookeeper/templates/service.yaml
+++ b/src/zookeeper/templates/service.yaml
@@ -7,9 +7,11 @@ metadata:
     chart: {{ template "zookeeper.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.service.annotations }}
   annotations:
 {{- with .Values.service.annotations }}
 {{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
@@ -18,6 +20,22 @@ spec:
     - name: {{ $key }}
 {{ toYaml $value | indent 6 }}
   {{- end }}
+{{- if .Values.exporters.jmx.enabled }}
+  {{- range $key, $port := .Values.exporters.jmx.ports }}
+    - name: {{ $key }}
+      port: {{ $port.containerPort }}
+      targetPort: {{ $key }}
+      protocol: {{ $port.protocol }}
+  {{- end }}
+{{- end}}
+{{- if .Values.exporters.zookeeper.enabled }}
+  {{- range $key, $port := .Values.exporters.zookeeper.ports }}
+    - name: {{ $key }}
+      port: {{ $port.containerPort }}
+      targetPort: {{ $key }}
+      protocol: {{ $port.protocol }}
+  {{- end }}
+{{- end}}
   selector:
     app: {{ template "zookeeper.name" . }}
     release: {{ .Release.Name }}

--- a/src/zookeeper/templates/servicemonitors.yaml
+++ b/src/zookeeper/templates/servicemonitors.yaml
@@ -1,0 +1,56 @@
+{{- if and .Values.exporters.jmx.enabled .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "zookeeper.fullname" . }}
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+{{ toYaml .Values.prometheus.serviceMonitor.selector | indent 4 }}
+spec:
+  endpoints:
+  {{- range $key, $port := .Values.exporters.jmx.ports }}
+    - port: {{ $key }}
+      path: {{ $.Values.exporters.jmx.path }}
+      interval: {{ $.Values.exporters.jmx.serviceMonitor.interval }}
+      scrapeTimeout: {{ $.Values.exporters.jmx.serviceMonitor.scrapeTimeout }}
+      scheme: {{ $.Values.exporters.jmx.serviceMonitor.scheme }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "zookeeper.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}
+---
+
+{{- if and .Values.exporters.zookeeper.enabled .Values.prometheus.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "zookeeper.fullname" . }}-exporter
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+{{ toYaml .Values.prometheus.serviceMonitor.selector | indent 4 }}
+spec:
+  endpoints:
+  {{- range $key, $port := .Values.exporters.zookeeper.ports }}
+    - port: {{ $key }}
+      path: {{ $.Values.exporters.zookeeper.path }}
+      interval: {{ $.Values.exporters.zookeeper.serviceMonitor.interval }}
+      scrapeTimeout: {{ $.Values.exporters.zookeeper.serviceMonitor.scrapeTimeout }}
+      scheme: {{ $.Values.exporters.zookeeper.serviceMonitor.scheme }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ include "zookeeper.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/src/zookeeper/templates/statefulset.yaml
+++ b/src/zookeeper/templates/statefulset.yaml
@@ -103,15 +103,10 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
-            {{- range $secret := .Values.secrets }}
-              {{- if $secret.mountPath }}
-                {{- range $key := $secret.keys }}
-            - name: {{ $.Release.Name }}-{{ $secret.name }}
-              mountPath: {{ $secret.mountPath }}/{{ $key }}
-              subPath: {{ $key }}
+            {{- if (.Values.secret) and (.Values.secret.enabled) }}
+            - name: secret
+              mountPath: {{ .Values.secret.mountPath }}
               readOnly: true
-                {{- end }}
-              {{- end }}
             {{- end }}
             - name: config
               mountPath: /config-scripts
@@ -192,10 +187,10 @@ spec:
           configMap:
             name: {{ template "zookeeper.fullname" . }}
             defaultMode: 0555
-        {{- range .Values.secrets }}
-        - name: {{ $.Release.Name }}-{{ .name }}
+        {{- if (.Values.secret) and (.Values.secret.enabled) }}
+        - name: secret
           secret:
-            secretName: {{ .name }}
+            secretName: {{ .Values.secret.secretName }}
         {{- end }}
         {{- if .Values.exporters.jmx.enabled }}
         - name: config-jmx-exporter

--- a/src/zookeeper/templates/statefulset.yaml
+++ b/src/zookeeper/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "zookeeper.fullname" . }}
@@ -9,9 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
     component: server
 spec:
-  serviceName: {{ template "zookeeper.fullname" . }}-headless
+  serviceName: {{ template "zookeeper.headless" . }}
   replicas: {{ .Values.replicaCount }}
-  terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
   selector:
     matchLabels:
       app: {{ template "zookeeper.name" . }}
@@ -31,37 +30,58 @@ spec:
         {{ $key }}: {{ $value | quote }}
         {{- end }}
       {{- end }}
+{{- if .Values.podAnnotations }}
       annotations:
-      {{- if .Values.podAnnotations }}
         ## Custom pod annotations
         {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-      {{- end }}
+{{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- if .Values.schedulerName }}
       schedulerName: "{{ .Values.schedulerName }}"
 {{- end }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+{{- end }}
       containers:
 
         - name: zookeeper
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/bash
-            - -xec
-            - zkGenConfig.sh && exec zkServer.sh start-foreground
+        {{- with .Values.command }}
+          command: {{ range . }}
+             - {{ . | quote }}
+          {{- end }}
+        {{- end }}
           ports:
 {{- range $key, $port := .Values.ports }}
             - name: {{ $key }}
 {{ toYaml $port | indent 14 }}
 {{- end }}
           livenessProbe:
-{{ toYaml .Values.livenessProbe | indent 12 }}
+            exec:
+              command:
+                - sh
+                - /config-scripts/ok
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 2
+            successThreshold: 1
           readinessProbe:
-{{ toYaml .Values.readinessProbe | indent 12 }}
+            exec:
+              command:
+                - sh
+                - /config-scripts/ready
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 2
+            successThreshold: 1
           env:
             - name: ZK_REPLICAS
               value: {{ .Values.replicaCount | quote }}
@@ -69,16 +89,33 @@ spec:
             - name: {{ $key | upper | replace "." "_" }}
               value: {{ $value | quote }}
           {{- end }}
+          {{- range $secret := .Values.secrets }}
+            {{- range $key := $secret.keys }}
+            - name: {{ (print $secret.name "_" $key) | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secret.name }}
+                  key: {{ $key }}
+            {{- end }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
             - name: data
-              mountPath: /var/lib/zookeeper
-            {{- if (.Values.secret) and (.Values.secret.enabled) }}
-            - name: secret
-              mountPath: {{ .Values.secret.mountPath }}
+              mountPath: /data
+            {{- range $secret := .Values.secrets }}
+              {{- if $secret.mountPath }}
+                {{- range $key := $secret.keys }}
+            - name: {{ $.Release.Name }}-{{ $secret.name }}
+              mountPath: {{ $secret.mountPath }}/{{ $key }}
+              subPath: {{ $key }}
               readOnly: true
+                {{- end }}
+              {{- end }}
             {{- end }}
+            - name: config
+              mountPath: /config-scripts
+
 
 {{- if .Values.exporters.jmx.enabled }}
         - name: jmx-exporter
@@ -151,10 +188,14 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
       volumes:
-        {{- if (.Values.secret) and (.Values.secret.enabled) }}
-        - name: secret
+        - name: config
+          configMap:
+            name: {{ template "zookeeper.fullname" . }}
+            defaultMode: 0555
+        {{- range .Values.secrets }}
+        - name: {{ $.Release.Name }}-{{ .name }}
           secret:
-            secretName: {{ .Values.secret.secretName }}
+            secretName: {{ .name }}
         {{- end }}
         {{- if .Values.exporters.jmx.enabled }}
         - name: config-jmx-exporter

--- a/src/zookeeper/values.yaml
+++ b/src/zookeeper/values.yaml
@@ -9,20 +9,15 @@ podDisruptionBudget:
 
 terminationGracePeriodSeconds: 1800  # Duration in seconds a Zokeeper pod needs to terminate gracefully.
 
-## OnDelete requires you to manually delete each pod when making updates.
-## This approach is at the moment safer than RollingUpdate because replication
-## may be incomplete when replication source pod is killed.
-##
-## ref: http://blog.kubernetes.io/2017/09/kubernetes-statefulsets-daemonsets.html
 updateStrategy:
-  type: OnDelete  # Pods will only be created when you manually delete old pods.
+  type: RollingUpdate
 
 ## refs:
 ## - https://github.com/kubernetes/contrib/tree/master/statefulsets/zookeeper
 ## - https://github.com/kubernetes/contrib/blob/master/statefulsets/zookeeper/Makefile#L1
 image:
-  repository: gcr.io/google_samples/k8szk  # Container image repository for zookeeper container.
-  tag: v3  # Container image tag for zookeeper container.
+  repository: zookeeper     # Container image repository for zookeeper container.
+  tag: 3.5.5                # Container image tag for zookeeper container.
   pullPolicy: IfNotPresent  # Image pull criteria for zookeeper container.
 
 service:
@@ -38,6 +33,10 @@ service:
       targetPort: client  # Service target port for client port.
       protocol: TCP  # Service port protocol for client port.
 
+## Headless service.
+##
+headless:
+  annotations: {}
 
 ports:
   client:
@@ -62,6 +61,8 @@ resources: {}  # Optionally specify how much CPU and memory (RAM) each zookeeper
   #  cpu: 100m
   #  memory: 128Mi
 
+priorityClassName: ""
+
 nodeSelector: {}  # Node label-values required to run zookeeper pods.
 
 tolerations: []  # Node taint overrides for zookeeper pods.
@@ -83,29 +84,32 @@ podLabels: {}  # Key/value pairs that are attached to zookeeper pods.
   # team: "developers"
   # service: "zookeeper"
 
-livenessProbe:
-  exec:
-    command:
-      - zkOk.sh
-  initialDelaySeconds: 20
-  # periodSeconds: 30
-  # timeoutSeconds: 30
-  # failureThreshold: 6
-  # successThreshold: 1
-
-readinessProbe:
-  exec:
-    command:
-      - zkOk.sh
-  initialDelaySeconds: 20
-  # periodSeconds: 30
-  # timeoutSeconds: 30
-  # failureThreshold: 6
-  # successThreshold: 1
-
 securityContext:
   fsGroup: 1000
   runAsUser: 1000
+
+## Useful, if you want to use an alternate image.
+command:
+  - /bin/bash
+  - -xec
+  - /config-scripts/run
+
+## Useful if using any custom authorizer.
+## Pass any secrets to the kafka pods. Each secret will be passed as an
+## environment variable by default. The secret can also be mounted to a
+## specific path (in addition to environment variable) if required. Environment
+## variable names are generated as: `<secretName>_<secretKey>` (All upper case)
+# secrets:
+# - name: myKafkaSecret
+#   keys:
+#     - username
+#     - password
+#   # mountPath: /opt/kafka/secret
+# - name: myZkSecret
+#   keys:
+#     - user
+#     - pass
+#   mountPath: /opt/zookeeper/secret
 
 persistence:
   enabled: true
@@ -119,13 +123,6 @@ persistence:
   # storageClass: "-"
   accessMode: ReadWriteOnce
   size: 5Gi
-
-secret:
-  ## Mounting secret. Useful for JAAS/Kerberos.
-  ##
-  enabled: false
-  mountPath: /opt/zookeeper/secret
-  secretName: zookeeper-secret
 
 ## Exporters query apps for metrics and make those metrics available for
 ## Prometheus to scrape.
@@ -183,6 +180,10 @@ exporters:
       timeoutSeconds: 60
       failureThreshold: 8
       successThreshold: 1
+    serviceMonitor:
+      interval: 30s
+      scrapeTimeout: 30s
+      scheme: http
 
   zookeeper:
   ## refs:
@@ -222,6 +223,21 @@ exporters:
       timeoutSeconds: 60
       failureThreshold: 8
       successThreshold: 1
+    serviceMonitor:
+      interval: 30s
+      scrapeTimeout: 30s
+      scheme: http
+
+## ServiceMonitor configuration in case you are using Prometheus Operator
+prometheus:
+  serviceMonitor:
+    ## If true a ServiceMonitor for each enabled exporter will be installed
+    enabled: false
+    ## The namespace where the ServiceMonitor(s) will be installed
+    # namespace: monitoring
+    ## The selector the Prometheus instance is searching for
+    ## [Default Prometheus Operator selector] (https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74)
+    selector: {}
 
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
@@ -239,43 +255,17 @@ env:
   JMXSSL: "false"
 
   ## The port on which the server will accept client requests.
-  ZK_CLIENT_PORT: 2181
-
-  ## The port on which the ensemble performs leader election.
-  ZK_ELECTION_PORT: 3888
-
-  ## The JVM heap size.
-  ZK_HEAP_SIZE: 2G
+  ZOO_PORT: 2181
 
   ## The number of Ticks that an ensemble member is allowed to perform leader
   ## election.
-  ZK_INIT_LIMIT: 5
+  ZOO_INIT_LIMIT: 5
 
-  ## The Log Level that for the ZooKeeper processes logger.
-  ## Choices are `TRACE,DEBUG,INFO,WARN,ERROR,FATAL`.
-  ZK_LOG_LEVEL: INFO
+  ZOO_TICK_TIME: 2000
 
   ## The maximum number of concurrent client connections that
   ## a server in the ensemble will accept.
-  ZK_MAX_CLIENT_CNXNS: 60
-
-  ## The maximum session timeout that the ensemble will allow a client to request.
-  ## Upstream default is `20 * ZK_TICK_TIME`
-  ZK_MAX_SESSION_TIMEOUT: 40000
-
-  ## The minimum session timeout that the ensemble will allow a client to request.
-  ## Upstream default is `2 * ZK_TICK_TIME`.
-  ZK_MIN_SESSION_TIMEOUT: 4000
-
-  ## The delay, in hours, between ZooKeeper log and snapshot cleanups.
-  ZK_PURGE_INTERVAL: 0
-
-  ## The port on which the leader will send events to followers.
-  ZK_SERVER_PORT: 2888
-
-  ## The number of snapshots that the ZooKeeper process will retain if
-  ## `ZK_PURGE_INTERVAL` is set to a value greater than `0`.
-  ZK_SNAP_RETAIN_COUNT: 3
+  ZOO_MAX_CLIENT_CNXNS: 60
 
   ## The number of Tick by which a follower may lag behind the ensembles leader.
   ZK_SYNC_LIMIT: 10
@@ -284,8 +274,9 @@ env:
   ## internal time.
   ZK_TICK_TIME: 2000
 
-  ## Example for passing JAAS config.
-  # SERVER_JVMFLAGS: -Djava.security.auth.login.config=/opt/zookeeper/secret/zookeeper_server_jaas.conf
+  ZOO_AUTOPURGE_PURGEINTERVAL: 0
+  ZOO_AUTOPURGE_SNAPRETAINCOUNT: 3
+  ZOO_STANDALONE_ENABLED: false
 
 jobs:
   ## ref: http://zookeeper.apache.org/doc/r3.4.10/zookeeperProgrammers.html#ch_zkSessions


### PR DESCRIPTION
Current Zookeeper chart and application version is dated. Moreover current chart support image "repository: gcr.io/google_samples/k8szk" which is older zookeeper version 3.4.10. This image is no more supported and this image is for sample purpose and not fit for production use in the first place. We are updating to docker hub latest supported stable version 3.5.5 and latest k8s chart. Since the latest chart is broken because of syntax error in one of the helm templates, I am fixing it here. We want to host this chart version until below PR is merged to helm/charts to address syntax error issue.

https://github.com/helm/charts/pull/18275

We have a PSIRT defect to upgrade zookeeper version and we don't have much time to wait till this PR is merged.